### PR TITLE
Add supertest as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   },
   "author": "avbel",
   "license": "MIT",
+  "peerDependencies": {
+    "supertest": "~0"
+  },
   "devDependencies": {
     "should": "~3.3.0",
     "koa": "~0.5.4",


### PR DESCRIPTION
This enables having `co-supertest` as only dependency in `package.json` for those who don't want the redundancy of adding `supertest` manually.
