### PR TITLE
Log response body in case of error

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,9 @@ Test.prototype.end = function(){
     oldEnd.call(self, function(err, res){
       // allow events handlers to run first
       process.nextTick(function(){
+        if (err && res.body && Object.keys(res.body).length > 0) {
+          console.log("Response body", res.body);
+        }
         callback(err, res);
       });
     });


### PR DESCRIPTION
Hi, this little change makes the `co-supertest` much usable for me. Maybe I'm missing something but when my `.expect(status_code)` fails I really want to see the response body to understand what happened. Or is there another way how to achieve this without modifying `co-supertest`?